### PR TITLE
Ensure network connectivity in sshtunnel@.service

### DIFF
--- a/sshtunnel@.service
+++ b/sshtunnel@.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=SSH Tunnel managment
-Requires=network.target
-After=network.service
+Requires=network-online.target
+After=network-online.target network.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
I've had a few issues, where the `sshtunnel` services were consistently starting before my network becomes fully operational and therefore exiting with errors like

```
<redacted> sshtunnel[508]: ssh: Could not resolve hostname <redacted>: Name or service not known
<redacted> autossh[508]: ssh exited prematurely with status 255; autossh exiting
```

Interestingly enough, `network.service` doesn't even exist on my system and googling this service didn't yield any convincing results. Was this a typo? Was it supposed to be `After=network.target` like the `Requires` section? I've also found, that waiting for `network-online.target` instead of `network.target` yielded better results.

This PR changes the `.target` from `network` to `network-online` and adds it to both the `Requires` as well as `After` sections.